### PR TITLE
Parse house pdf

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,3 @@
-Note: this repository draws from the joeisdone.github.io repository.
-
-
 To use `parse_house_pdf.py`, you must have `pdfplumber` installed in your python environment.
 Instructions for installing it are below.
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,42 @@
+Note: this repository draws from the joeisdone.github.io repository.
+
+
+To use `parse_house_pdf.py`, you must have `pdfplumber` installed in your python environment.
+Instructions for installing it are below.
+
+# Installation
+In your virtual environment (or your root environment if you're a cowboy) run:
+```
+pip install -r requirements.txt
+```
+to install all the modules required for this program to work.
+
+## Python Virtual environment
+It's best practice to create a python virtual environment for installing a project's python modules.
+You can create a python virtual environment like so:
+```
+python -m venv my-environment
+```
+The author recommends that the python virtual environment be created in your home directory under a
+folder named `venv`. So, on windows:
+```
+C:\Users\you>md venv
+C:\Users\you>python -m venv .\venv\my-env
+```
+Unix like:
+```
+$ mkdir ~/venv
+$ python3 -m venv ~/venv/my-env
+```
+You may activate them like so:
+Windows:
+```
+C:\Users\you>.\venv\my-env\Scripts\activate
+```
+Unix like:
+```
+$ . ./venv/bin/activate
+```
+
+After your virtual environment is activated, you may install python modules without
+worrying about conflicts with other projects.

--- a/python/parse_house_pdf.py
+++ b/python/parse_house_pdf.py
@@ -1,10 +1,13 @@
-import pdfplumber
 import re
+import sys
+import argparse
 
-PDF_PATH = "CR.pdf"
-lines = []
+import pdfplumber
 
-def analyze_pdf_structure(pdf_path, sample_pages=25):
+CLEANER_REGEX = r"^\d+(?:\s+|$)"
+
+
+def main(pdf_path, out_file, start_page, stop_page, ignore):
     # Open the PDF
     with pdfplumber.open(pdf_path) as pdf:
         # Basic PDF info
@@ -20,40 +23,49 @@ def analyze_pdf_structure(pdf_path, sample_pages=25):
         else:
             print("No metadata found.")
 
-        # Limit the number of pages we inspect to avoid huge output
-        pages_to_inspect = min(sample_pages, total_pages)
-        
-        for i in range(sample_pages): #replace with total_pages when ready to parse the whole thing
+        if (
+            stop_page == -1 or stop_page > total_pages
+        ):  # i.e. we want to analyze to the end
+            stop_page = total_pages
+
+        lines = []
+        for i in range(start_page, stop_page):
             page = pdf.pages[i]
             print(f"\n--- Analyzing page {i+1}/{total_pages} ---")
 
             # Extract raw text:
             raw_text = page.extract_text()
             if raw_text:
-                lines.extend(raw_text.split('\n'))
+                lines.extend(raw_text.split("\n"))
                 continue
                 print("Sample of Extracted Text:")
                 print(raw_text[:500] + "...")  # Just show a snippet
 
-
             else:
-                print("No text extracted on this page.")
+                print(f"No text extracted on this page ({i+1}/{total_pages}).")
 
             # Inspect characters and fonts
             chars = page.chars
             if chars:
                 # chars is a list of dicts with keys like text, fontname, size, x0, x1, top, bottom, etc.
                 # Let's show unique fonts used on the page
-                fonts_used = {char['fontname'] for char in chars if 'fontname' in char}
+                fonts_used = {char["fontname"] for char in chars if "fontname" in char}
                 print(f"Fonts used on this page: {fonts_used}")
-                
+
                 # Show character positioning details for first few characters
                 print("Character samples (x0, top, text, fontname):")
                 for char in chars[:10]:
-                    print((char['x0'], char['top'], char['text'], char.get('fontname', 'Unknown')))
+                    print(
+                        (
+                            char["x0"],
+                            char["top"],
+                            char["text"],
+                            char.get("fontname", "Unknown"),
+                        )
+                    )
             else:
                 print("No character-level data found on this page.")
-            
+
             # If you want to analyze layout more, you can look at lines and words:
             # pdfplumber allows for extracting words as structured objects:
             words = page.extract_words()
@@ -61,8 +73,8 @@ def analyze_pdf_structure(pdf_path, sample_pages=25):
                 print(f"Total words extracted on this page: {len(words)}")
                 # Show a few sample words with their bounding boxes
                 for w in words[:10]:
-                    print((w['text'], w['x0'], w['top'], w['x1'], w['bottom']))
-            
+                    print((w["text"], w["x0"], w["top"], w["x1"], w["bottom"]))
+
             # You can also inspect any tables detected (if the layout is table-like)
             # This can help understand if you need special handling:
             tables = page.extract_tables()
@@ -73,22 +85,52 @@ def analyze_pdf_structure(pdf_path, sample_pages=25):
             else:
                 print("No tables detected on this page (or unable to parse as tables).")
 
-    cleaned = []
-    for line in lines:
-        if '\\' in line: 
-            continue
-        if 'December 17' in line: # Replace with something else
-            continue
-        cleaned_line = re.sub(r'^\d+(?:\s+|$)', '', line)
-        cleaned.append(cleaned_line)
-
-    # Specify the filename you want to write to
-    filename = "CR.txt"
-
     # Write the lines to the file, separated by a newline
-    with open(filename, 'w', encoding='utf-8') as f:
-        for line in cleaned:
-            f.write(line + "\n")
+    with open(out_file, "w", encoding="utf-8") as handle:  # as in file handle
+        for line in lines:
+            if "\\" in line:
+                continue
+            if ignore == "":
+                pass  # do nothing
+            elif ignore in line:
+                continue
+            cleaned_line = re.sub(CLEANER_REGEX, "", line)
+            handle.write(cleaned_line)
+            handle.write("\n")
+    return 0
+
 
 if __name__ == "__main__":
-    analyze_pdf_structure(PDF_PATH, sample_pages=25)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pdf", help="The path to the pdf file you want to parse.")
+    parser.add_argument(
+        "-o",
+        "--out",
+        type=str,
+        default="out.txt",
+        help="The filename for the output text.",
+    )
+    parser.add_argument(
+        "--start_page",
+        type=int,
+        default=0,
+        help="Start parsing with this page number (start counting at 0; i.e. page 1 is start_page 0).",
+    )
+    parser.add_argument(
+        "--stop_page",
+        type=int,
+        default=-1,
+        help="Stop parsing before this page number. Parsing does not include this page number. If not set, then the parsing will continue to the end of the document.",
+    )
+    parser.add_argument(
+        "--ignore",
+        default="",
+        help="Ignore lines containing this string. If no string is passed, then no lines are ignored.",
+    )
+    args = parser.parse_args()
+    pdf_path = args.pdf
+    out_file = args.out
+    start_page = args.start_page
+    stop_page = args.stop_page
+    ignore = args.ignore
+    sys.exit(main(pdf_path, out_file, start_page, stop_page, ignore))

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,1 @@
+pdfplumber


### PR DESCRIPTION
    Parse House PDF
    
    The `parse_house_pdf.py` script now takes arguments from the command
    line. You may run `python parse_house_pdf.py --help` for information on
    the command line arguments. The script now may parse sections of a PDF
    by passing `start_page` and, optionally, `stop_page` flags. Moreover,
    the `ignore` flag parameterizes the feature where lines containing a
    specific string (e.g. 'December 17') will be ignored.
    
    The script has also been formatted to conform to PEP 8 using the tool
    `black` (also a python module). This does not materially affect the
    script, but makes it easier for python developers to read.
    
    Finally, a `README.md` and `requirements.txt` file have been added to
    the project so that there is documentation for installing the modules
    necessary for running the script.
