### PR TITLE
Make Graphviz suck less

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -846,17 +846,14 @@ select {
 .h-6 {
   height: 1.5rem;
 }
-.h-\[74px\] {
-  height: 74px;
-}
-.h-full {
-  height: 100%;
-}
 .h-\[59px\] {
   height: 59px;
 }
 .h-\[82px\] {
   height: 82px;
+}
+.h-full {
+  height: 100%;
 }
 .min-h-\[44px\] {
   min-height: 44px;

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -846,17 +846,14 @@ select {
 .h-6 {
   height: 1.5rem;
 }
-.h-\[74px\] {
-  height: 74px;
-}
-.h-full {
-  height: 100%;
-}
 .h-\[59px\] {
   height: 59px;
 }
 .h-\[82px\] {
   height: 82px;
+}
+.h-full {
+  height: 100%;
 }
 .min-h-\[44px\] {
   min-height: 44px;

--- a/docs/expose/index.html
+++ b/docs/expose/index.html
@@ -905,7 +905,8 @@ labelloc="t";
     for (const ein of nodeSet) {
       const c = filteredCharities[ein];
       
-      const escapedName = c.name.replace(/[&<>"']/g, char => {
+      // First escape special characters
+      let escapedName = c.name.replace(/[&<>"']/g, char => {
         switch (char) {
           case '&': return '&amp;';
           case '<': return '&lt;';
@@ -915,15 +916,24 @@ labelloc="t";
           default: return char;
         }
       });
+
+      // Highlight keywords in the name
+      if (activeKeywords.length > 0) {
+        activeKeywords.forEach(kw => {
+          // Case-insensitive search, preserve leading and trailing whitespace
+          const regex = new RegExp(`(\\s*)(${kw})`, 'gi');
+          escapedName = escapedName.replace(regex, '$1<B><FONT COLOR="#2563EB">$2</FONT></B> ').trim();
+        });
+      }
       
       const receipts = formatNumber(c.receipt_amt);
       const govt = formatNumber(c.govt_amt);
       const contrib = formatNumber(c.contrib_amt);
       const grants = formatNumber(c.grant_amt);
       
-      // Enhanced table formatting
+      // Enhanced table formatting - removed outer <B> tags
       const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3" CELLPADDING="4">
-        <TR><TD COLSPAN="2"><B>${escapedName}</B></TD></TR>
+        <TR><TD COLSPAN="2">${escapedName}</TD></TR>
         <TR>
           <TD ALIGN="LEFT"><FONT POINT-SIZE="12">EIN:</FONT></TD>
           <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">${ein}</FONT></TD>

--- a/docs/expose/index.html
+++ b/docs/expose/index.html
@@ -950,16 +950,30 @@ labelloc="t";
         </TR>
       </TABLE>>`;
       
-      // Style based on taxpayer funds
+      // Style based on taxpayer funds AND user search
       let nodeStyle = '';
-      if (c.govt_amt > 10000000) {
-        nodeStyle = 'fillcolor="#FEE2E2" color="#DC2626"';
-      } else if (c.govt_amt > 1000000) {
-        nodeStyle = 'fillcolor="#FEF3C7" color="#D97706"';
-      } else if (c.govt_amt > 0) {
-        nodeStyle = 'fillcolor="#F3F4F6" color="#4B5563"';
+      if (activeEINs.includes(ein)) {
+        // Highlight user-searched nodes with a thicker border and different color
+        if (c.govt_amt > 10000000) {
+          nodeStyle = 'fillcolor="#FEE2E2" color="#DC2626" penwidth=3';
+        } else if (c.govt_amt > 1000000) {
+          nodeStyle = 'fillcolor="#FEF3C7" color="#D97706" penwidth=3';
+        } else if (c.govt_amt > 0) {
+          nodeStyle = 'fillcolor="#F3F4F6" color="#2563EB" penwidth=3';  // Blue for emphasis
+        } else {
+          nodeStyle = 'fillcolor="#F3F4F6" color="#2563EB" penwidth=3';  // Blue for emphasis
+        }
       } else {
-        nodeStyle = 'fillcolor="#F3F4F6" color="#94A3B8"';
+        // Normal styling for other nodes
+        if (c.govt_amt > 10000000) {
+          nodeStyle = 'fillcolor="#FEE2E2" color="#DC2626"';
+        } else if (c.govt_amt > 1000000) {
+          nodeStyle = 'fillcolor="#FEF3C7" color="#D97706"';
+        } else if (c.govt_amt > 0) {
+          nodeStyle = 'fillcolor="#F3F4F6" color="#4B5563"';
+        } else {
+          nodeStyle = 'fillcolor="#F3F4F6" color="#94A3B8"';
+        }
       }
 
       dot += `  "${ein}" [${nodeStyle}, label=${label}];\n`;

--- a/docs/expose/index.html
+++ b/docs/expose/index.html
@@ -947,6 +947,10 @@ labelloc="t";
           </td>
         </tr>
         <TR><TD COLSPAN="3" align="left"><b>${escapedName}</b></TD><td>&nbsp;</td></TR>
+        <TR>
+          <TD colspan="3" align="left">EIN: ${ein.slice(0,2)}-${ein.slice(2)}</TD>
+          <td>&nbsp;</td>
+        </TR>
         <tr>
           <td colspan="4">
           <table border="0" cellspacing="0" cellpadding="0">
@@ -954,12 +958,6 @@ labelloc="t";
           </table>
           </td>
         </tr>
-        <TR>
-          <TD align="left">EIN</TD>
-          <td>&nbsp;</td>
-          <TD align="right">${ein.slice(0,2)}-${ein.slice(2)}</TD>
-          <td>&nbsp;</td>
-        </TR>
         <TR>
           <TD align="left">Gross receipts</TD>
           <td>&nbsp;</td>
@@ -982,8 +980,8 @@ labelloc="t";
           <td colspan="3">
           <table border="0" cellspacing="0" cellpadding="0">
             <TR>
-              <TD align="left" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}><B align="left">Taxpayer funds</B></TD>
-              <TD align="right" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}><B align="right">$${govt}</B></TD>
+              <TD align="left"><FONT ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : 'COLOR="#000"'}><B align="left">Taxpayer funds</B></FONT></TD>
+              <TD align="right"><FONT ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : 'COLOR="#000"'}><B align="right">$${govt}</B></FONT></TD>
             </TR>
           </table>
           </td>
@@ -1062,9 +1060,13 @@ labelloc="t";
   function renderActiveEINs() {
     const $c = $('#activeEINs');
     $c.empty();
+    
+    // Show/hide Clear EINs button based on activeEINs length
+    $('#clearEINsBtn').toggle(activeEINs.length > 0);
+    
     activeEINs.forEach(ein => {
       const $tag = $('<div class="filter-tag flex items-center gap-0.5 rounded border border-blue-600 bg-blue-100 text-blue-600 rounded-md px-2 py-1 bg-blue-100 text-xs"></div>');
-      const $text = $('<span></span>').text(ein);
+      const $text = $('<span></span>').text(ein.slice(0,2) + '-' + ein.slice(2));
       const $rm = $('<span class="remove-filter opacity-50 hover:opacity-100 size-5 -my-0.5 -mr-1 cursor-pointer"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="#000" fill-rule="evenodd" d="M2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10S2 17.523 2 12Zm7.53-3.53a.75.75 0 0 0-1.06 1.06L10.94 12l-2.47 2.47a.75.75 0 1 0 1.06 1.06L12 13.06l2.47 2.47a.75.75 0 1 0 1.06-1.06L13.06 12l2.47-2.47a.75.75 0 0 0-1.06-1.06L12 10.94 9.53 8.47Z" clip-rule="evenodd"/></svg></span>').attr('data-ein', ein);
       $rm.on('click', function() {
         const rem = $(this).attr('data-ein');
@@ -1095,6 +1097,10 @@ labelloc="t";
   function renderActiveKeywords() {
     const $c = $('#activeFilters');
     $c.empty();
+    
+    // Show/hide Clear keywords button based on activeKeywords length
+    $('#clearFiltersBtn').toggle(activeKeywords.length > 0);
+    
     activeKeywords.forEach(kw => {
       const $tag = $('<div class="filter-tag flex items-center gap-0.5 rounded border border-blue-600 bg-blue-100 text-blue-600 rounded-md px-2 py-1 bg-blue-100 text-xs"></div>');
       const $text = $('<span></span>').text(kw);

--- a/docs/expose/index.html
+++ b/docs/expose/index.html
@@ -881,7 +881,7 @@ node [
   color="#94A3B8",
   fontname="SF Pro, Helvetica, sans-serif",
   fontsize=14,
-  margin=0.4,
+  margin=0.2,
   penwidth=1.5
 ];
 edge [
@@ -932,7 +932,7 @@ labelloc="t";
       const grants = formatNumber(c.grant_amt);
       
       // Enhanced table formatting - removed outer <B> tags
-      const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3" CELLPADDING="4">
+      const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3" CELLPADDING="2">
         <TR><TD COLSPAN="2">${escapedName}</TD></TR>
         <TR>
           <TD ALIGN="LEFT"><FONT POINT-SIZE="12">EIN:</FONT></TD>

--- a/docs/expose/index.html
+++ b/docs/expose/index.html
@@ -41,16 +41,16 @@ $(document).ready(function() {
 <meta property="og:locale" content="en_US" />
 <meta name="description" content="Joe Is Done" />
 <meta property="og:description" content="Joe Is Done" />
-<link rel="canonical" href="https://datarepublican.com/expose/" />
-<meta property="og:url" content="https://datarepublican.com/expose/" />
+<link rel="canonical" href="http://localhost:4000/expose/" />
+<meta property="og:url" content="http://localhost:4000/expose/" />
 <meta property="og:site_name" content="DataRepublican" />
-<meta property="og:image" content="https://datarepublican.com/assets/images/default.png" />
+<meta property="og:image" content="http://localhost:4000/assets/images/default.png" />
 <meta property="og:type" content="website" />
 <meta name="twitter:card" content="summary_large_image" />
-<meta property="twitter:image" content="https://datarepublican.com/assets/images/default.png" />
+<meta property="twitter:image" content="http://localhost:4000/assets/images/default.png" />
 <meta property="twitter:title" content="Charity graph - multi-root BFS &amp; taxpayer totals" />
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"WebPage","description":"Joe Is Done","headline":"Charity graph - multi-root BFS &amp; taxpayer totals","image":"https://datarepublican.com/assets/images/default.png","url":"https://datarepublican.com/expose/"}</script>
+{"@context":"https://schema.org","@type":"WebPage","description":"Joe Is Done","headline":"Charity graph - multi-root BFS &amp; taxpayer totals","image":"http://localhost:4000/assets/images/default.png","url":"http://localhost:4000/expose/"}</script>
 <!-- End Jekyll SEO tag -->
 
 </head>
@@ -480,7 +480,7 @@ $(document).ready(function() {
         // remove dashes
         let v = e.replace(/[-\s]/g, '');
         if (/^\d{9}$/.test(v)) {
-          // We'll add it if it’s in our CSV or not - user might want it anyway
+          // We'll add it if it's in our CSV or not - user might want it anyway
           if (!activeEINs.includes(v)) {
             activeEINs.push(v);
           }
@@ -875,15 +875,28 @@ $(document).ready(function() {
 // Graph settings
 rankdir=LR;
 node [
-  shape=ellipse, 
-  style=filled, 
-  fillcolor=lightblue, 
-  color=black,
+  shape=box,
+  style="rounded,filled",
+  fillcolor="#F3F4F6",
+  color="#94A3B8",
   fontname="SF Pro, Helvetica, sans-serif",
-  fontsize=14
+  fontsize=14,
+  margin=0.4,
+  penwidth=1.5
 ];
-edge [fontname="Libre Franklin, SF Pro, Helvetica, sans-serif"];
-graph [fontname="Libre Franklin, SF Pro, Helvetica, sans-serif"];
+edge [
+  fontname="SF Pro, Helvetica, sans-serif",
+  color="#94A3B8",
+  penwidth=1.5,
+  fontsize=11,
+  decorate=true,
+  labelangle=0,
+  labeldistance=2
+];
+graph [
+  fontname="SF Pro, Helvetica, sans-serif",
+  splines=polyline
+];
 label="Charity Graph (multi-root BFS)";
 labelloc="t";
 `;
@@ -891,20 +904,71 @@ labelloc="t";
     // Add nodes
     for (const ein of nodeSet) {
       const c = filteredCharities[ein];
+      
+      const escapedName = c.name.replace(/[&<>"']/g, char => {
+        switch (char) {
+          case '&': return '&amp;';
+          case '<': return '&lt;';
+          case '>': return '&gt;';
+          case '"': return '&quot;';
+          case "'": return '&apos;';
+          default: return char;
+        }
+      });
+      
       const receipts = formatNumber(c.receipt_amt);
       const govt = formatNumber(c.govt_amt);
       const contrib = formatNumber(c.contrib_amt);
       const grants = formatNumber(c.grant_amt);
-      const taxpayerAlert = c.govt_amt > 10000000 ? '\\n🚨🚨🚨 High Taxpayer Funds Alert! 🚨🚨🚨' : '';
-      const label = `${c.name}\\nEIN: ${ein}\\nGross Receipts: $${receipts}\\nTaxpayer Funds Received: $${govt}${taxpayerAlert}\\nContributions: $${contrib}\\nGrants Given: $${grants}`;
-      const fillColor = c.govt_amt > 1000000 ? "#FFAD99" : "lightblue";
-      dot += `  "${ein}" [label="${label}", style=filled, fillcolor="${fillColor}"];\n`;
+      
+      // Enhanced table formatting
+      const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3" CELLPADDING="4">
+        <TR><TD COLSPAN="2"><B>${escapedName}</B></TD></TR>
+        <TR>
+          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">EIN:</FONT></TD>
+          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">${ein}</FONT></TD>
+        </TR>
+        <TR>
+          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Gross Receipts:</FONT></TD>
+          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${receipts}</FONT></TD>
+        </TR>
+        <TR>
+          <TD ALIGN="LEFT" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}>
+            <FONT POINT-SIZE="12"><B>Taxpayer Funds:</B></FONT>
+          </TD>
+          <TD ALIGN="RIGHT" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}>
+            <FONT POINT-SIZE="12"><B>$${govt}</B></FONT>
+          </TD>
+        </TR>
+        <TR>
+          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Contributions:</FONT></TD>
+          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${contrib}</FONT></TD>
+        </TR>
+        <TR>
+          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Grants Given:</FONT></TD>
+          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${grants}</FONT></TD>
+        </TR>
+      </TABLE>>`;
+      
+      // Style based on taxpayer funds
+      let nodeStyle = '';
+      if (c.govt_amt > 10000000) {
+        nodeStyle = 'fillcolor="#FEE2E2" color="#DC2626"';
+      } else if (c.govt_amt > 1000000) {
+        nodeStyle = 'fillcolor="#FEF3C7" color="#D97706"';
+      } else if (c.govt_amt > 0) {
+        nodeStyle = 'fillcolor="#F3F4F6" color="#4B5563"';
+      } else {
+        nodeStyle = 'fillcolor="#F3F4F6" color="#94A3B8"';
+      }
+
+      dot += `  "${ein}" [${nodeStyle}, label=${label}];\n`;
     }
 
-    // Add edges
+    // Add edges - explicitly set color for each edge
     for (const e of edgeList) {
       const amt = formatNumber(e.amt);
-      dot += `  "${e.filer}" -> "${e.grantee}" [label="$${amt}"];\n`;
+      dot += `  "${e.filer}" -> "${e.grantee}" [label="$${amt}", color="#94A3B8"];\n`;
     }
 
     dot += `}\n`;

--- a/docs/expose/index.html
+++ b/docs/expose/index.html
@@ -936,20 +936,20 @@ labelloc="t";
       // Enhanced table formatting
       const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="2" cellpadding="2">
         ${c.govt_amt > 10000000 ? `<tr>
-          <td colspan="2">
+          <td colspan="4">
           <table border="0" cellspacing="0" cellpadding="5"><TR><TD COLSPAN="2" BGCOLOR="#DC2626">
           <FONT COLOR="white"><B>🚨🚨🚨 High Taxpayer Funds Alert! 🚨🚨🚨</B></FONT>
           </TD></TR></table></td></tr>` : ''}
         <tr>
-          <td colspan="2">
+          <td colspan="4">
           <table border="0" cellspacing="0" cellpadding="0">
-            <TR><TD COLSPAN="2" HEIGHT="2"></TD></TR>
+            <TR><TD COLSPAN="4" HEIGHT="2"></TD></TR>
           </table>
           </td>
         </tr>
-        <TR><TD COLSPAN="2" align="left"><b>${escapedName}</b></TD></TR>
+        <TR><TD COLSPAN="3" align="left"><b>${escapedName}</b></TD><td>&nbsp;</td></TR>
         <tr>
-          <td colspan="2">
+          <td colspan="4">
           <table border="0" cellspacing="0" cellpadding="0">
             <TR><TD COLSPAN="2" BGCOLOR="#000000" HEIGHT="2"></TD></TR>
           </table>
@@ -957,22 +957,30 @@ labelloc="t";
         </tr>
         <TR>
           <TD align="left">EIN</TD>
+          <td>&nbsp;</td>
           <TD align="right">${ein.slice(0,2)}-${ein.slice(2)}</TD>
+          <td>&nbsp;</td>
         </TR>
         <TR>
           <TD align="left">Gross receipts</TD>
+          <td>&nbsp;</td>
           <TD align="right">$${receipts}</TD>
+          <td>&nbsp;</td>
         </TR>
         <TR>
           <TD align="left">Contributions</TD>
+          <td>&nbsp;</td>
           <TD align="right">$${contrib}</TD>
+          <td>&nbsp;</td>
         </TR>
         <TR>
           <TD align="left">Grants given</TD>
+          <td>&nbsp;</td>
           <TD align="right">$${grants}</TD>
+          <td>&nbsp;</td>
         </TR>
         <tr>
-          <td colspan="2">
+          <td colspan="3">
           <table border="0" cellspacing="0" cellpadding="0">
             <TR>
               <TD align="left" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}><B align="left">Taxpayer funds</B></TD>
@@ -980,6 +988,7 @@ labelloc="t";
             </TR>
           </table>
           </td>
+          <td>&nbsp;</td>
         </tr>
       </TABLE>>`;
       

--- a/docs/expose/index.html
+++ b/docs/expose/index.html
@@ -874,15 +874,17 @@ $(document).ready(function() {
     let dot = `digraph G {
 // Graph settings
 rankdir=LR;
+nodesep=0.5;  // Increase horizontal spacing between nodes
+ranksep=0.5;  // Increase vertical spacing between ranks
 node [
   shape=box,
-  style="rounded,filled",
+  style="filled",
   fillcolor="#F3F4F6",
   color="#94A3B8",
   fontname="SF Pro, Helvetica, sans-serif",
   fontsize=14,
-  margin=0.2,
-  penwidth=1.5
+  margin=0.1,
+  penwidth=1
 ];
 edge [
   fontname="SF Pro, Helvetica, sans-serif",
@@ -931,33 +933,54 @@ labelloc="t";
       const contrib = formatNumber(c.contrib_amt);
       const grants = formatNumber(c.grant_amt);
       
-      // Enhanced table formatting - removed outer <B> tags
-      const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3" CELLPADDING="2">
-        <TR><TD COLSPAN="2">${escapedName}</TD></TR>
+      // Enhanced table formatting
+      const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="2" cellpadding="2">
+        ${c.govt_amt > 10000000 ? `<tr>
+          <td colspan="2">
+          <table border="0" cellspacing="0" cellpadding="5"><TR><TD COLSPAN="2" BGCOLOR="#DC2626">
+          <FONT COLOR="white"><B>🚨🚨🚨 High Taxpayer Funds Alert! 🚨🚨🚨</B></FONT>
+          </TD></TR></table></td></tr>` : ''}
+        <tr>
+          <td colspan="2">
+          <table border="0" cellspacing="0" cellpadding="0">
+            <TR><TD COLSPAN="2" HEIGHT="2"></TD></TR>
+          </table>
+          </td>
+        </tr>
+        <TR><TD COLSPAN="2" align="left"><b>${escapedName}</b></TD></TR>
+        <tr>
+          <td colspan="2">
+          <table border="0" cellspacing="0" cellpadding="0">
+            <TR><TD COLSPAN="2" BGCOLOR="#000000" HEIGHT="2"></TD></TR>
+          </table>
+          </td>
+        </tr>
         <TR>
-          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">EIN:</FONT></TD>
-          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">${ein}</FONT></TD>
+          <TD align="left">EIN</TD>
+          <TD align="right">${ein.slice(0,2)}-${ein.slice(2)}</TD>
         </TR>
         <TR>
-          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Gross Receipts:</FONT></TD>
-          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${receipts}</FONT></TD>
+          <TD align="left">Gross receipts</TD>
+          <TD align="right">$${receipts}</TD>
         </TR>
         <TR>
-          <TD ALIGN="LEFT" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}>
-            <FONT POINT-SIZE="12"><B>Taxpayer Funds:</B></FONT>
-          </TD>
-          <TD ALIGN="RIGHT" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}>
-            <FONT POINT-SIZE="12"><B>$${govt}</B></FONT>
-          </TD>
+          <TD align="left">Contributions</TD>
+          <TD align="right">$${contrib}</TD>
         </TR>
         <TR>
-          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Contributions:</FONT></TD>
-          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${contrib}</FONT></TD>
+          <TD align="left">Grants given</TD>
+          <TD align="right">$${grants}</TD>
         </TR>
-        <TR>
-          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Grants Given:</FONT></TD>
-          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${grants}</FONT></TD>
-        </TR>
+        <tr>
+          <td colspan="2">
+          <table border="0" cellspacing="0" cellpadding="0">
+            <TR>
+              <TD align="left" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}><B align="left">Taxpayer funds</B></TD>
+              <TD align="right" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}><B align="right">$${govt}</B></TD>
+            </TR>
+          </table>
+          </td>
+        </tr>
       </TABLE>>`;
       
       // Style based on taxpayer funds AND user search

--- a/docs/expose/index.html
+++ b/docs/expose/index.html
@@ -899,7 +899,6 @@ graph [
   fontname="SF Pro, Helvetica, sans-serif",
   splines=polyline
 ];
-label="Charity Graph (multi-root BFS)";
 labelloc="t";
 `;
 

--- a/expose/index.html
+++ b/expose/index.html
@@ -658,6 +658,10 @@ labelloc="t";
           </td>
         </tr>
         <TR><TD COLSPAN="3" align="left"><b>${escapedName}</b></TD><td>&nbsp;</td></TR>
+        <TR>
+          <TD colspan="3" align="left">EIN: ${ein.slice(0,2)}-${ein.slice(2)}</TD>
+          <td>&nbsp;</td>
+        </TR>
         <tr>
           <td colspan="4">
           <table border="0" cellspacing="0" cellpadding="0">
@@ -665,12 +669,6 @@ labelloc="t";
           </table>
           </td>
         </tr>
-        <TR>
-          <TD align="left">EIN</TD>
-          <td>&nbsp;</td>
-          <TD align="right">${ein.slice(0,2)}-${ein.slice(2)}</TD>
-          <td>&nbsp;</td>
-        </TR>
         <TR>
           <TD align="left">Gross receipts</TD>
           <td>&nbsp;</td>
@@ -693,8 +691,8 @@ labelloc="t";
           <td colspan="3">
           <table border="0" cellspacing="0" cellpadding="0">
             <TR>
-              <TD align="left" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}><B align="left">Taxpayer funds</B></TD>
-              <TD align="right" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}><B align="right">$${govt}</B></TD>
+              <TD align="left"><FONT ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : 'COLOR="#000"'}><B align="left">Taxpayer funds</B></FONT></TD>
+              <TD align="right"><FONT ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : 'COLOR="#000"'}><B align="right">$${govt}</B></FONT></TD>
             </TR>
           </table>
           </td>
@@ -773,9 +771,13 @@ labelloc="t";
   function renderActiveEINs() {
     const $c = $('#activeEINs');
     $c.empty();
+    
+    // Show/hide Clear EINs button based on activeEINs length
+    $('#clearEINsBtn').toggle(activeEINs.length > 0);
+    
     activeEINs.forEach(ein => {
       const $tag = $('<div class="filter-tag flex items-center gap-0.5 rounded border border-blue-600 bg-blue-100 text-blue-600 rounded-md px-2 py-1 bg-blue-100 text-xs"></div>');
-      const $text = $('<span></span>').text(ein);
+      const $text = $('<span></span>').text(ein.slice(0,2) + '-' + ein.slice(2));
       const $rm = $('<span class="remove-filter opacity-50 hover:opacity-100 size-5 -my-0.5 -mr-1 cursor-pointer">{% include close.html %}</span>').attr('data-ein', ein);
       $rm.on('click', function() {
         const rem = $(this).attr('data-ein');
@@ -806,6 +808,10 @@ labelloc="t";
   function renderActiveKeywords() {
     const $c = $('#activeFilters');
     $c.empty();
+    
+    // Show/hide Clear keywords button based on activeKeywords length
+    $('#clearFiltersBtn').toggle(activeKeywords.length > 0);
+    
     activeKeywords.forEach(kw => {
       const $tag = $('<div class="filter-tag flex items-center gap-0.5 rounded border border-blue-600 bg-blue-100 text-blue-600 rounded-md px-2 py-1 bg-blue-100 text-xs"></div>');
       const $text = $('<span></span>').text(kw);

--- a/expose/index.html
+++ b/expose/index.html
@@ -616,7 +616,8 @@ labelloc="t";
     for (const ein of nodeSet) {
       const c = filteredCharities[ein];
       
-      const escapedName = c.name.replace(/[&<>"']/g, char => {
+      // First escape special characters
+      let escapedName = c.name.replace(/[&<>"']/g, char => {
         switch (char) {
           case '&': return '&amp;';
           case '<': return '&lt;';
@@ -626,15 +627,24 @@ labelloc="t";
           default: return char;
         }
       });
+
+      // Highlight keywords in the name
+      if (activeKeywords.length > 0) {
+        activeKeywords.forEach(kw => {
+          // Case-insensitive search, preserve leading and trailing whitespace
+          const regex = new RegExp(`(\\s*)(${kw})`, 'gi');
+          escapedName = escapedName.replace(regex, '$1<B><FONT COLOR="#2563EB">$2</FONT></B> ').trim();
+        });
+      }
       
       const receipts = formatNumber(c.receipt_amt);
       const govt = formatNumber(c.govt_amt);
       const contrib = formatNumber(c.contrib_amt);
       const grants = formatNumber(c.grant_amt);
       
-      // Enhanced table formatting
+      // Enhanced table formatting - removed outer <B> tags
       const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3" CELLPADDING="4">
-        <TR><TD COLSPAN="2"><B>${escapedName}</B></TD></TR>
+        <TR><TD COLSPAN="2">${escapedName}</TD></TR>
         <TR>
           <TD ALIGN="LEFT"><FONT POINT-SIZE="12">EIN:</FONT></TD>
           <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">${ein}</FONT></TD>

--- a/expose/index.html
+++ b/expose/index.html
@@ -592,7 +592,7 @@ node [
   color="#94A3B8",
   fontname="SF Pro, Helvetica, sans-serif",
   fontsize=14,
-  margin=0.4,
+  margin=0.2,
   penwidth=1.5
 ];
 edge [
@@ -643,7 +643,7 @@ labelloc="t";
       const grants = formatNumber(c.grant_amt);
       
       // Enhanced table formatting - removed outer <B> tags
-      const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3" CELLPADDING="4">
+      const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3" CELLPADDING="2">
         <TR><TD COLSPAN="2">${escapedName}</TD></TR>
         <TR>
           <TD ALIGN="LEFT"><FONT POINT-SIZE="12">EIN:</FONT></TD>

--- a/expose/index.html
+++ b/expose/index.html
@@ -610,7 +610,6 @@ graph [
   fontname="SF Pro, Helvetica, sans-serif",
   splines=polyline
 ];
-label="Charity Graph (multi-root BFS)";
 labelloc="t";
 `;
 

--- a/expose/index.html
+++ b/expose/index.html
@@ -647,20 +647,20 @@ labelloc="t";
       // Enhanced table formatting
       const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="2" cellpadding="2">
         ${c.govt_amt > 10000000 ? `<tr>
-          <td colspan="2">
+          <td colspan="4">
           <table border="0" cellspacing="0" cellpadding="5"><TR><TD COLSPAN="2" BGCOLOR="#DC2626">
           <FONT COLOR="white"><B>🚨🚨🚨 High Taxpayer Funds Alert! 🚨🚨🚨</B></FONT>
           </TD></TR></table></td></tr>` : ''}
         <tr>
-          <td colspan="2">
+          <td colspan="4">
           <table border="0" cellspacing="0" cellpadding="0">
-            <TR><TD COLSPAN="2" HEIGHT="2"></TD></TR>
+            <TR><TD COLSPAN="4" HEIGHT="2"></TD></TR>
           </table>
           </td>
         </tr>
-        <TR><TD COLSPAN="2" align="left"><b>${escapedName}</b></TD></TR>
+        <TR><TD COLSPAN="3" align="left"><b>${escapedName}</b></TD><td>&nbsp;</td></TR>
         <tr>
-          <td colspan="2">
+          <td colspan="4">
           <table border="0" cellspacing="0" cellpadding="0">
             <TR><TD COLSPAN="2" BGCOLOR="#000000" HEIGHT="2"></TD></TR>
           </table>
@@ -668,22 +668,30 @@ labelloc="t";
         </tr>
         <TR>
           <TD align="left">EIN</TD>
+          <td>&nbsp;</td>
           <TD align="right">${ein.slice(0,2)}-${ein.slice(2)}</TD>
+          <td>&nbsp;</td>
         </TR>
         <TR>
           <TD align="left">Gross receipts</TD>
+          <td>&nbsp;</td>
           <TD align="right">$${receipts}</TD>
+          <td>&nbsp;</td>
         </TR>
         <TR>
           <TD align="left">Contributions</TD>
+          <td>&nbsp;</td>
           <TD align="right">$${contrib}</TD>
+          <td>&nbsp;</td>
         </TR>
         <TR>
           <TD align="left">Grants given</TD>
+          <td>&nbsp;</td>
           <TD align="right">$${grants}</TD>
+          <td>&nbsp;</td>
         </TR>
         <tr>
-          <td colspan="2">
+          <td colspan="3">
           <table border="0" cellspacing="0" cellpadding="0">
             <TR>
               <TD align="left" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}><B align="left">Taxpayer funds</B></TD>
@@ -691,6 +699,7 @@ labelloc="t";
             </TR>
           </table>
           </td>
+          <td>&nbsp;</td>
         </tr>
       </TABLE>>`;
       

--- a/expose/index.html
+++ b/expose/index.html
@@ -661,16 +661,30 @@ labelloc="t";
         </TR>
       </TABLE>>`;
       
-      // Style based on taxpayer funds
+      // Style based on taxpayer funds AND user search
       let nodeStyle = '';
-      if (c.govt_amt > 10000000) {
-        nodeStyle = 'fillcolor="#FEE2E2" color="#DC2626"';
-      } else if (c.govt_amt > 1000000) {
-        nodeStyle = 'fillcolor="#FEF3C7" color="#D97706"';
-      } else if (c.govt_amt > 0) {
-        nodeStyle = 'fillcolor="#F3F4F6" color="#4B5563"';
+      if (activeEINs.includes(ein)) {
+        // Highlight user-searched nodes with a thicker border and different color
+        if (c.govt_amt > 10000000) {
+          nodeStyle = 'fillcolor="#FEE2E2" color="#DC2626" penwidth=3';
+        } else if (c.govt_amt > 1000000) {
+          nodeStyle = 'fillcolor="#FEF3C7" color="#D97706" penwidth=3';
+        } else if (c.govt_amt > 0) {
+          nodeStyle = 'fillcolor="#F3F4F6" color="#2563EB" penwidth=3';  // Blue for emphasis
+        } else {
+          nodeStyle = 'fillcolor="#F3F4F6" color="#2563EB" penwidth=3';  // Blue for emphasis
+        }
       } else {
-        nodeStyle = 'fillcolor="#F3F4F6" color="#94A3B8"';
+        // Normal styling for other nodes
+        if (c.govt_amt > 10000000) {
+          nodeStyle = 'fillcolor="#FEE2E2" color="#DC2626"';
+        } else if (c.govt_amt > 1000000) {
+          nodeStyle = 'fillcolor="#FEF3C7" color="#D97706"';
+        } else if (c.govt_amt > 0) {
+          nodeStyle = 'fillcolor="#F3F4F6" color="#4B5563"';
+        } else {
+          nodeStyle = 'fillcolor="#F3F4F6" color="#94A3B8"';
+        }
       }
 
       dot += `  "${ein}" [${nodeStyle}, label=${label}];\n`;

--- a/expose/index.html
+++ b/expose/index.html
@@ -585,15 +585,17 @@ title: Charity graph - multi-root BFS & taxpayer totals
     let dot = `digraph G {
 // Graph settings
 rankdir=LR;
+nodesep=0.5;  // Increase horizontal spacing between nodes
+ranksep=0.5;  // Increase vertical spacing between ranks
 node [
   shape=box,
-  style="rounded,filled",
+  style="filled",
   fillcolor="#F3F4F6",
   color="#94A3B8",
   fontname="SF Pro, Helvetica, sans-serif",
   fontsize=14,
-  margin=0.2,
-  penwidth=1.5
+  margin=0.1,
+  penwidth=1
 ];
 edge [
   fontname="SF Pro, Helvetica, sans-serif",
@@ -642,33 +644,54 @@ labelloc="t";
       const contrib = formatNumber(c.contrib_amt);
       const grants = formatNumber(c.grant_amt);
       
-      // Enhanced table formatting - removed outer <B> tags
-      const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3" CELLPADDING="2">
-        <TR><TD COLSPAN="2">${escapedName}</TD></TR>
+      // Enhanced table formatting
+      const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="2" cellpadding="2">
+        ${c.govt_amt > 10000000 ? `<tr>
+          <td colspan="2">
+          <table border="0" cellspacing="0" cellpadding="5"><TR><TD COLSPAN="2" BGCOLOR="#DC2626">
+          <FONT COLOR="white"><B>🚨🚨🚨 High Taxpayer Funds Alert! 🚨🚨🚨</B></FONT>
+          </TD></TR></table></td></tr>` : ''}
+        <tr>
+          <td colspan="2">
+          <table border="0" cellspacing="0" cellpadding="0">
+            <TR><TD COLSPAN="2" HEIGHT="2"></TD></TR>
+          </table>
+          </td>
+        </tr>
+        <TR><TD COLSPAN="2" align="left"><b>${escapedName}</b></TD></TR>
+        <tr>
+          <td colspan="2">
+          <table border="0" cellspacing="0" cellpadding="0">
+            <TR><TD COLSPAN="2" BGCOLOR="#000000" HEIGHT="2"></TD></TR>
+          </table>
+          </td>
+        </tr>
         <TR>
-          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">EIN:</FONT></TD>
-          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">${ein}</FONT></TD>
+          <TD align="left">EIN</TD>
+          <TD align="right">${ein.slice(0,2)}-${ein.slice(2)}</TD>
         </TR>
         <TR>
-          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Gross Receipts:</FONT></TD>
-          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${receipts}</FONT></TD>
+          <TD align="left">Gross receipts</TD>
+          <TD align="right">$${receipts}</TD>
         </TR>
         <TR>
-          <TD ALIGN="LEFT" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}>
-            <FONT POINT-SIZE="12"><B>Taxpayer Funds:</B></FONT>
-          </TD>
-          <TD ALIGN="RIGHT" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}>
-            <FONT POINT-SIZE="12"><B>$${govt}</B></FONT>
-          </TD>
+          <TD align="left">Contributions</TD>
+          <TD align="right">$${contrib}</TD>
         </TR>
         <TR>
-          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Contributions:</FONT></TD>
-          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${contrib}</FONT></TD>
+          <TD align="left">Grants given</TD>
+          <TD align="right">$${grants}</TD>
         </TR>
-        <TR>
-          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Grants Given:</FONT></TD>
-          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${grants}</FONT></TD>
-        </TR>
+        <tr>
+          <td colspan="2">
+          <table border="0" cellspacing="0" cellpadding="0">
+            <TR>
+              <TD align="left" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}><B align="left">Taxpayer funds</B></TD>
+              <TD align="right" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}><B align="right">$${govt}</B></TD>
+            </TR>
+          </table>
+          </td>
+        </tr>
       </TABLE>>`;
       
       // Style based on taxpayer funds AND user search

--- a/expose/index.html
+++ b/expose/index.html
@@ -191,7 +191,7 @@ title: Charity graph - multi-root BFS & taxpayer totals
         // remove dashes
         let v = e.replace(/[-\s]/g, '');
         if (/^\d{9}$/.test(v)) {
-          // We'll add it if it’s in our CSV or not - user might want it anyway
+          // We'll add it if it's in our CSV or not - user might want it anyway
           if (!activeEINs.includes(v)) {
             activeEINs.push(v);
           }
@@ -586,15 +586,28 @@ title: Charity graph - multi-root BFS & taxpayer totals
 // Graph settings
 rankdir=LR;
 node [
-  shape=ellipse, 
-  style=filled, 
-  fillcolor=lightblue, 
-  color=black,
+  shape=box,
+  style="rounded,filled",
+  fillcolor="#F3F4F6",
+  color="#94A3B8",
   fontname="SF Pro, Helvetica, sans-serif",
-  fontsize=14
+  fontsize=14,
+  margin=0.4,
+  penwidth=1.5
 ];
-edge [fontname="Libre Franklin, SF Pro, Helvetica, sans-serif"];
-graph [fontname="Libre Franklin, SF Pro, Helvetica, sans-serif"];
+edge [
+  fontname="SF Pro, Helvetica, sans-serif",
+  color="#94A3B8",
+  penwidth=1.5,
+  fontsize=11,
+  decorate=true,
+  labelangle=0,
+  labeldistance=2
+];
+graph [
+  fontname="SF Pro, Helvetica, sans-serif",
+  splines=polyline
+];
 label="Charity Graph (multi-root BFS)";
 labelloc="t";
 `;
@@ -602,20 +615,71 @@ labelloc="t";
     // Add nodes
     for (const ein of nodeSet) {
       const c = filteredCharities[ein];
+      
+      const escapedName = c.name.replace(/[&<>"']/g, char => {
+        switch (char) {
+          case '&': return '&amp;';
+          case '<': return '&lt;';
+          case '>': return '&gt;';
+          case '"': return '&quot;';
+          case "'": return '&apos;';
+          default: return char;
+        }
+      });
+      
       const receipts = formatNumber(c.receipt_amt);
       const govt = formatNumber(c.govt_amt);
       const contrib = formatNumber(c.contrib_amt);
       const grants = formatNumber(c.grant_amt);
-      const taxpayerAlert = c.govt_amt > 10000000 ? '\\n🚨🚨🚨 High Taxpayer Funds Alert! 🚨🚨🚨' : '';
-      const label = `${c.name}\\nEIN: ${ein}\\nGross Receipts: $${receipts}\\nTaxpayer Funds Received: $${govt}${taxpayerAlert}\\nContributions: $${contrib}\\nGrants Given: $${grants}`;
-      const fillColor = c.govt_amt > 1000000 ? "#FFAD99" : "lightblue";
-      dot += `  "${ein}" [label="${label}", style=filled, fillcolor="${fillColor}"];\n`;
+      
+      // Enhanced table formatting
+      const label = `<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3" CELLPADDING="4">
+        <TR><TD COLSPAN="2"><B>${escapedName}</B></TD></TR>
+        <TR>
+          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">EIN:</FONT></TD>
+          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">${ein}</FONT></TD>
+        </TR>
+        <TR>
+          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Gross Receipts:</FONT></TD>
+          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${receipts}</FONT></TD>
+        </TR>
+        <TR>
+          <TD ALIGN="LEFT" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}>
+            <FONT POINT-SIZE="12"><B>Taxpayer Funds:</B></FONT>
+          </TD>
+          <TD ALIGN="RIGHT" ${c.govt_amt > 0 ? 'COLOR="#DC2626"' : ''}>
+            <FONT POINT-SIZE="12"><B>$${govt}</B></FONT>
+          </TD>
+        </TR>
+        <TR>
+          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Contributions:</FONT></TD>
+          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${contrib}</FONT></TD>
+        </TR>
+        <TR>
+          <TD ALIGN="LEFT"><FONT POINT-SIZE="12">Grants Given:</FONT></TD>
+          <TD ALIGN="RIGHT"><FONT POINT-SIZE="12">$${grants}</FONT></TD>
+        </TR>
+      </TABLE>>`;
+      
+      // Style based on taxpayer funds
+      let nodeStyle = '';
+      if (c.govt_amt > 10000000) {
+        nodeStyle = 'fillcolor="#FEE2E2" color="#DC2626"';
+      } else if (c.govt_amt > 1000000) {
+        nodeStyle = 'fillcolor="#FEF3C7" color="#D97706"';
+      } else if (c.govt_amt > 0) {
+        nodeStyle = 'fillcolor="#F3F4F6" color="#4B5563"';
+      } else {
+        nodeStyle = 'fillcolor="#F3F4F6" color="#94A3B8"';
+      }
+
+      dot += `  "${ein}" [${nodeStyle}, label=${label}];\n`;
     }
 
-    // Add edges
+    // Add edges - explicitly set color for each edge
     for (const e of edgeList) {
       const amt = formatNumber(e.amt);
-      dot += `  "${e.filer}" -> "${e.grantee}" [label="$${amt}"];\n`;
+      dot += `  "${e.filer}" -> "${e.grantee}" [label="$${amt}", color="#94A3B8"];\n`;
     }
 
     dot += `}\n`;


### PR DESCRIPTION
[Graphviz](https://graphviz.org/documentation/) sucks a lot, but this makes it suck a little less.

## Highlights currently searched EIN with a blue border

<img width="1367" alt="image" src="https://github.com/user-attachments/assets/747a249c-bc28-41bd-98f8-1c6c1f084e27" />

## Highlights searched keywords in blue

<img width="805" alt="image" src="https://github.com/user-attachments/assets/ecdc1002-11d6-462a-a3b6-e4f9fcb1f445" />

## Overall styling

Overall just better, more polished styling. And formatted/organized the content in the nodes.

Not perfect, as Graphviz has some very strange quirks, but this is about as good as we'll get it for now.

This is all applied to the `/expose` page, but when we have other pages that use Graphviz, it should be pretty straightforward to copy over the changes.

Definitely worth a good run-through before merging to make sure I didn't miss anything in a non-obvious use case!